### PR TITLE
Fix broken terminal removing unecessary char

### DIFF
--- a/.bash_prompt
+++ b/.bash_prompt
@@ -59,7 +59,7 @@ function parse_git_branch() {
 }
 
 
-PS2="\[$YELLOW\]⚡️  ➜ \[$RESET\]";
+PS2="\[$YELLOW\]⚡  ➜ \[$RESET\]";
 
 PS1="\[\e]2;$PWD\[\a\]\[\e]1;\]$(basename "$(dirname "$PWD")")/\W\[\a\]";
 PS1+="\[${BOLD}${MAGENTA}\]\u\[$WHITE\]@\[$ORANGE\]\h \[$WHITE\]in ";


### PR DESCRIPTION
With .bash_prompt, terminal was showing a weird behavior when navigating through history:

```sh
# press up key
⚡️  ➜ git status

# press down key
⚡️  ➜ g
# can't delete first char

#press up key
⚡️  ➜ ggit status
# first char is kept
```

I can't say exactly why this occur, but, removing an apparently unused special char fixed the problem.

#needMoreTests