### PR TITLE
Fix repeat when press and hold key on MacOS Sierra

### DIFF
--- a/osx.sh
+++ b/osx.sh
@@ -144,7 +144,8 @@ defaults write com.apple.universalaccess closeViewZoomFollowsFocus -bool true
 defaults write NSGlobalDomain ApplePressAndHoldEnabled -bool false
 
 # Set a blazingly fast keyboard repeat rate
-defaults write NSGlobalDomain KeyRepeat -int 0
+defaults write NSGlobalDomain KeyRepeat -int 1
+defaults write NSGlobalDomain InitialKeyRepeat -int 20
 
 # Set language and text formats
 # Note: if you’re in the US, replace `EUR` with `USD`, `Centimeters` with


### PR DESCRIPTION
Fixes #12

Apparently, MacOS Sierra does not accept parameter KeyRepeat value 0
anymore. Changed to 1 and it's still extremely fast. Also add a
interval to start repeating.